### PR TITLE
03장 로그인하기

### DIFF
--- a/03장/src/main/java/util/ModelUtils.java
+++ b/03장/src/main/java/util/ModelUtils.java
@@ -4,13 +4,20 @@ import model.User;
 
 import java.util.Map;
 
+import static db.DataBase.findUserById;
+
 public class ModelUtils {
-    public static void createUser(Map<String, String> parameters) {
-        new User(
+    public static User createUser(Map<String, String> parameters) {
+        return new User(
                 parameters.get("userId"),
                 parameters.get("password"),
                 parameters.get("name"),
                 parameters.get("email")
         );
+    }
+
+    public static boolean isUser(String userId, String password) {
+        User user = findUserById(userId);
+        return user != null && user.getPassword().equals(password);
     }
 }

--- a/03장/src/main/java/util/ModelUtils.java
+++ b/03장/src/main/java/util/ModelUtils.java
@@ -18,6 +18,9 @@ public class ModelUtils {
 
     public static boolean isUser(String userId, String password) {
         User user = findUserById(userId);
-        return user != null && user.getPassword().equals(password);
+        if(user == null || !user.getPassword().equals(password)) {
+            throw new UserNotFoundException();
+        }
+        return true;
     }
 }

--- a/03장/src/main/java/util/UserNotFoundException.java
+++ b/03장/src/main/java/util/UserNotFoundException.java
@@ -1,0 +1,4 @@
+package util;
+
+public class UserNotFoundException extends RuntimeException{
+}

--- a/03장/src/main/java/webserver/RequestHandler.java
+++ b/03장/src/main/java/webserver/RequestHandler.java
@@ -85,7 +85,9 @@ public class RequestHandler extends Thread {
                     response302Header(dos);
                     responseBody(dos, body);
                 }
-            } else {
+            } if(pathParams.equals("/user/login.html")) {
+            }
+            }else {
                 body = Files.readAllBytes(new File("./webapp" + pathParams).toPath());
                 response200Header(dos, body.length);
                 responseBody(dos, body);

--- a/03장/src/main/java/webserver/RequestHandler.java
+++ b/03장/src/main/java/webserver/RequestHandler.java
@@ -81,7 +81,9 @@ public class RequestHandler extends Thread {
                     Map<String, String> parameters = HttpRequestUtils.parseQueryString(content);
 
                     ModelUtils.createUser(parameters);
+                    body = Files.readAllBytes(new File("./webapp" + pathParams).toPath());
                     response302Header(dos);
+                    responseBody(dos, body);
                 }
             } else {
                 body = Files.readAllBytes(new File("./webapp" + pathParams).toPath());

--- a/03장/src/main/java/webserver/RequestHandler.java
+++ b/03장/src/main/java/webserver/RequestHandler.java
@@ -7,6 +7,8 @@ import java.util.ArrayList;
 import java.util.Map;
 
 import com.google.common.base.Strings;
+import db.DataBase;
+import model.User;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,6 +36,7 @@ public class RequestHandler extends Thread {
 
             ArrayList<String> requestInfos = new ArrayList<>();
             String info;
+            Map<String, String> parameters;
 
             while(!"".equals(info = reader.readLine())) {
                 if (info == null) { return; } // NullPointerException 처리 안해도 되나?
@@ -64,7 +67,7 @@ public class RequestHandler extends Thread {
                     pathParams = "/user/form.html";
 
                     if (!Strings.isNullOrEmpty(queryParams)) {
-                        Map<String, String> parameters = HttpRequestUtils.parseQueryString(queryParams);
+                        parameters = HttpRequestUtils.parseQueryString(queryParams);
                         ModelUtils.createUser(parameters);
                     }
                     body = Files.readAllBytes(new File("./webapp" + pathParams).toPath());
@@ -78,16 +81,16 @@ public class RequestHandler extends Thread {
                     StringReader sr = new StringReader(data);
                     BufferedReader br = new BufferedReader(sr);
                     String content = IOUtils.readData(br, HttpRequestUtils.getContentLength(requestInfos));
-                    Map<String, String> parameters = HttpRequestUtils.parseQueryString(content);
+                    parameters = HttpRequestUtils.parseQueryString(content);
 
-                    ModelUtils.createUser(parameters);
+                    User user = ModelUtils.createUser(parameters);
+                    DataBase.addUser(user);
                     body = Files.readAllBytes(new File("./webapp" + pathParams).toPath());
                     response302Header(dos);
                     responseBody(dos, body);
                 }
             } if(pathParams.equals("/user/login.html")) {
-            }
-            }else {
+            } else {
                 body = Files.readAllBytes(new File("./webapp" + pathParams).toPath());
                 response200Header(dos, body.length);
                 responseBody(dos, body);

--- a/03장/src/main/java/webserver/RequestHandler.java
+++ b/03장/src/main/java/webserver/RequestHandler.java
@@ -15,6 +15,9 @@ import org.slf4j.LoggerFactory;
 import util.HttpRequestUtils;
 import util.IOUtils;
 import util.ModelUtils;
+import util.UserNotFoundException;
+
+import static util.ModelUtils.isUser;
 
 public class RequestHandler extends Thread {
     private static final Logger log = LoggerFactory.getLogger(RequestHandler.class);
@@ -104,6 +107,18 @@ public class RequestHandler extends Thread {
         try {
             dos.writeBytes("HTTP/1.1 200 OK \r\n");
             dos.writeBytes("Content-Type: text/html;charset=utf-8\r\n");
+            dos.writeBytes("Set-Cookie: logined=false\r\n");
+            dos.writeBytes("Content-Length: " + lengthOfBodyContent + "\r\n");
+            dos.writeBytes("\r\n");
+        } catch (IOException e) {
+            log.error(e.getMessage());
+        }
+    }
+    private void response200Header(DataOutputStream dos, int lengthOfBodyContent, boolean logined) {
+        try {
+            dos.writeBytes("HTTP/1.1 200 OK \r\n");
+            dos.writeBytes("Content-Type: text/html;charset=utf-8\r\n");
+            dos.writeBytes("Set-Cookie: logined=" + logined + "\r\n");
             dos.writeBytes("Content-Length: " + lengthOfBodyContent + "\r\n");
             dos.writeBytes("\r\n");
         } catch (IOException e) {

--- a/03장/src/test/java/util/ModelUtilTest.java
+++ b/03장/src/test/java/util/ModelUtilTest.java
@@ -1,11 +1,13 @@
 package util;
 
+import db.DataBase;
 import model.User;
 import org.junit.Test;
 
 import java.util.Map;
 
 import static org.junit.Assert.*;
+import static util.ModelUtils.isUser;
 
 public class ModelUtilTest {
 
@@ -23,5 +25,26 @@ public class ModelUtilTest {
         assertEquals("password2", user.getPassword());
         assertEquals("coin6442", user.getEmail());
         assertEquals("yelim", user.getName());
+    }
+
+    @Test
+    public void validateUser() {
+        // 유저 생성
+        String queryParams = "userId=javajigi&password=password2&email=coin6442&name=yelim";
+        Map<String, String> parameters = HttpRequestUtils.parseQueryString(queryParams);
+        User user = ModelUtils.createUser(parameters);
+        DataBase.addUser(user);
+
+        // 올바르게 입력했을 때
+        String input1 = "userId=javajigi&password=password2&email=coin6442&name=yelim";
+        Map<String, String> inputs1 = HttpRequestUtils.parseQueryString(input1);
+
+        assertTrue(isUser(inputs1.get("userId"), inputs1.get("password")));
+
+        // 올바르지 않게 입력했을 때
+        String input2 = "userId=hihihi&password=password2&email=coin6442&name=yelim";
+        Map<String, String> inputs2 = HttpRequestUtils.parseQueryString(input2);
+
+        assertFalse(isUser(inputs2.get("userId"), inputs2.get("password")));
     }
 }

--- a/03장/src/test/java/util/ModelUtilTest.java
+++ b/03장/src/test/java/util/ModelUtilTest.java
@@ -40,11 +40,13 @@ public class ModelUtilTest {
         Map<String, String> inputs1 = HttpRequestUtils.parseQueryString(input1);
 
         assertTrue(isUser(inputs1.get("userId"), inputs1.get("password")));
+    }
 
-        // 올바르지 않게 입력했을 때
-        String input2 = "userId=hihihi&password=password2&email=coin6442&name=yelim";
-        Map<String, String> inputs2 = HttpRequestUtils.parseQueryString(input2);
+    @Test(expected=UserNotFoundException.class)
+    public void invokeUserNotFoundException() {
+        String input2 = "userId=yelim&password=password2&email=coin6442&name=yelim";
+        Map<String, String> inputs1 = HttpRequestUtils.parseQueryString(input2);
 
-        assertFalse(isUser(inputs2.get("userId"), inputs2.get("password")));
+        isUser(inputs1.get("userId"), inputs1.get("password"));
     }
 }


### PR DESCRIPTION
- 로그인이 성공하면 /index.html로 이동하고, 로그인이 실패하면 `/user/login_failed.html`로 이동한다.
- 앞에서 회원가입한 사용자로 로그인할 수 있어야 한다.
- 로그인이 성공하면 쿠키를 활용해 로그인 상태를 유지할 수 있어야 한다.
- 로그인이 성공할 경우 요청 헤더의 Cookie 헤더 값이 `logined=true,` 로그인이 실패하면 Cookie 헤더 값이 `logined=false`로 전달되어야 한다.

### 체크 리스트
- [ ] 로그인 성공시 응답 헤더에 Set-Cookie를 추가해 로그인 성공 여부를 전달한다.
   
   ```
   HTTP/1.1 200 OK
   Content-Type: text/html
   Set-Cookie: logined=true
   ```
- [ ] 위와 같이 응답을 보내면 브라우저는 다음과 같이 HTTP 요청 헤더에 Cookie 값으로 전달한다. 이렇게 전달받은 Cookie 값으로 로그인 유무를 판단한다.   
   ```
   GET /index.html HTTP/1.1
   Host: localhost:8080
   Connection: keep-alive
   Accept: */*
   Cookie: logined=true
   ```
- [ ] 정상적으로 로그인 되었는지 확인하려면 앞 단계에서 회원가입한 데이터를 유지해야 한다.
    - 앞 단계에서 회원가입할 때 생성한 User 객체를 `Database.addUser()`메서드를 활용해 저장한다.
- [ ] 아이디와 비밀번호가 같은지를 확인해 로그인이 성공하면 응답 헤더의 Set-Cookie 값을 logined-true, 로그인이 실패할 경우 Set-Cookie 값을 logined=false로 설정한다.
- [ ] 응답 헤더에 Set-Cookie 값을 설정한 후 요청 헤더에 Cookie 값이 전달되는지 확인한다.